### PR TITLE
Updating API return value format

### DIFF
--- a/SHIELD.json
+++ b/SHIELD.json
@@ -1026,8 +1026,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "string",
-                                    "example": "1.2.3"
+                                    "properties": {
+                                        "appVersion": {
+                                            "description": "Follows symantec versioning as laid out here: https://semver.org/. This number is the version of the application package.",
+                                            "example": "1.2.3",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         },
@@ -1054,8 +1060,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "string",
-                                    "example": "1.2.3"
+                                    "properties": {
+                                        "appVersion": {
+                                            "description": "Follows symantec versioning as laid out here: https://semver.org/. This number is the version of the application package.",
+                                            "example": "1.2.3",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         },


### PR DESCRIPTION
String is notoriously tricky to handle on the receiving end as the content gets confused with possible JSON object. 
Updating the API return to be an object to avoid confusion.