### PR TITLE
Adding query search params

### DIFF
--- a/specs/Data-Gateway.json
+++ b/specs/Data-Gateway.json
@@ -73,6 +73,28 @@
                     "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$",
                     "type": "string"
                 }
+            },
+            "dateStart": {
+                "description": "Date string to narrow records selection to those created on or after that date.",
+                "in": "query",
+                "name": "dateStart",
+                "required": false,
+                "schema": {
+                    "example": "2025-01-01T00:00:00Z",
+                    "format": "date-time",
+                    "type": "string"
+                }
+            },
+            "dateEnd": {
+                "description": "Date string to narrow records selection to those created before or on that date.",
+                "in": "query",
+                "name": "dateEnd",
+                "required": false,
+                "schema": {
+                    "example": "2025-02-05T23:59:59Z",
+                    "format": "date-time",
+                    "type": "string"
+                }
             }
         },
         "responses": {
@@ -891,7 +913,7 @@
         },
         "description": "Collects data from the various SHI Lab products and makes it available in a standardized way.",
         "title": "SHI Data Gateway",
-        "version": "2.1.0"
+        "version": "2.1.1"
     },
     "openapi": "3.0.0",
     "paths": {
@@ -1077,8 +1099,16 @@
         },
         "/Api/LicenseReport/Correlation": {
             "get": {
-                "description": "Retrieves the list of correlation records for the authenticated tenant. Correlation records store the metadata for a specific license report.\n\nThis endpoint requires the `LicenseReport.Read`,  `LicenseReport.Read.All`, `LicenseReport.ReadWrite`, or `LicenseReport.ReadWrite.All` scope (permission).",
+                "description": "Retrieves the list of correlation records for the authenticated tenant. Can use filters targeting creation date to limit results. Correlation records store the metadata for a specific license report.\n\nThis endpoint requires the `LicenseReport.Read`,  `LicenseReport.Read.All`, `LicenseReport.ReadWrite`, or `LicenseReport.ReadWrite.All` scope (permission).",
                 "operationId": "/Api/LicenseReport/Correlation/Get",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/dateStart"
+                    },
+                    {
+                        "$ref": "#/components/parameters/dateEnd"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "content": {
@@ -1133,11 +1163,17 @@
         },
         "/Api/LicenseReport/Correlation/Tenant/{tenantId}": {
             "get": {
-                "description": "Retrieves the list of correlation records for the specified tenant. Correlation records store the metadata for a specific license report.\n\nThis endpoint requires the `LicenseReport.Read.All`, or `LicenseReport.ReadWrite.All` scope (permission). This endpoint is also only accessible form the `SHI` and `SHI Lab` tenants. End user access is restricted.",
+                "description": "Retrieves the list of correlation records for the specified tenant. Can use filters targeting creation date to limit results. Correlation records store the metadata for a specific license report.\n\nThis endpoint requires the `LicenseReport.Read.All`, or `LicenseReport.ReadWrite.All` scope (permission). This endpoint is also only accessible form the `SHI` and `SHI Lab` tenants. End user access is restricted.",
                 "operationId": "/Api/LicenseReport/Correlation/Tenant/:tenantId/Get",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/tenantId"
+                    },
+                    {
+                        "$ref": "#/components/parameters/dateStart"
+                    },
+                    {
+                        "$ref": "#/components/parameters/dateEnd"
                     }
                 ],
                 "responses": {

--- a/src/dataGateway/TypeScript/package.json
+++ b/src/dataGateway/TypeScript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shi-corp/sdk-data-gateway",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "main": "bin/index.js",
   "description": "SDK client used to interface with the SHI Data Gateway service.",


### PR DESCRIPTION
Updating 2 api endpoints to reflect support for query search parameters dateStart and dateEnd when retrieving License report data