### PR TITLE
LAB-1922A: Added templateName GET route and bump SDK version

### DIFF
--- a/specs/Data-Gateway.json
+++ b/specs/Data-Gateway.json
@@ -164,6 +164,28 @@
                         "value": "9b2c13f4-6e7a-4e8e-9c9a-a5b9c3f6ad12"
                     }
                 }
+            },
+            "templateName": {
+                "description": "Name of the Cloud Matrix template to retrieve.",
+                "in": "path",
+                "name": "templateName",
+                "required": true,
+                "schema": {
+                    "type": "string",
+                    "minLength": 2,
+                    "maxLength": 100,
+                    "pattern": "^[A-Za-z0-9][A-Za-z0-9_ -]*[A-Za-z0-9]$",
+                    "examples": [
+                        "Microsoft Enterprise"
+                    ]
+                },
+                "examples": {
+                    "valid template name": {
+                        "summary": "Example Valid Template Name",
+                        "description": "An example string of a valid template name.",
+                        "value": "Microsoft Enterprise"
+                    }
+                }
             }
         },
         "responses": {
@@ -9075,19 +9097,24 @@
                 "summary": "Get Cloud Matrix Correlation Records"
             }
         },
-        "/Api/CloudMatrix/Template": {
+        "/Api/CloudMatrix/Template/{templateName}": {
             "get": {
-                "description": "Get a default assessment schema object as schema structure reference. \n\nThis endpoint requires the `CloudMatrix.Read`, `CloudMatrix.Read.Del`, `CloudMatrix.Read.All`, `CloudMatrix.ReadWrite`, or `CloudMatrix.ReadWrite.All` scope (permission).",
-                "operationId": "/Api/CloudMatrix/Template/Get",
+                "description": "Retrieves the specified Cloud Matrix assessment template by template name. \n\nThis endpoint requires the `CloudMatrix.Read`, `CloudMatrix.Read.Del`, `CloudMatrix.Read.All`, `CloudMatrix.ReadWrite`, or `CloudMatrix.ReadWrite.All` scope (permission).",
+                "operationId": "/Api/CloudMatrix/Template/:templateName/Get",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/templateName"
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "The default assessment schema object.",
+                        "description": "The requested assessment template object.",
                         "content": {
                             "application/json": {
                                 "examples": {
-                                    "Default Output": {
-                                        "description": "Always returns the default schema template that stored in blob storage. This has been trimmed to contain one element for brevity.",
-                                        "summary": "Default Output",
+                                    "Named Template Output": {
+                                        "description": "Returns the requested template stored in blob storage. This has been trimmed to contain one element for brevity.",
+                                        "summary": "Named Template Output",
                                         "value": {
                                             "title": "CloudMatrix Value Assessment",
                                             "description": "MICROSOFT CLOUD ADOPTION MATRIX v5.0",
@@ -9275,8 +9302,10 @@
                 "tags": [
                     "Cloud Matrix"
                 ],
-                "summary": "Get a Default Assessment Schema Object"
-            },
+                "summary": "Get a Specific Assessment Template Schema Object"
+            }
+        },
+        "/Api/CloudMatrix/Template": {
             "post": {
                 "description": "Add or update a value assessment template. When the specified template name exists, it will overwrite the existing template JSON file in blob storage.\n\nThis endpoint is only accessible from the `SHI` and `SHI Lab` tenants and requires the `CloudMatrix.ReadWrite.All` scope (permission).",
                 "operationId": "/Api/CloudMatrix/Template/Post",

--- a/specs/Data-Gateway.json
+++ b/specs/Data-Gateway.json
@@ -171,16 +171,10 @@
                 "name": "templateName",
                 "required": true,
                 "schema": {
-                    "type": "string",
-                    "minLength": 2,
-                    "maxLength": 100,
-                    "pattern": "^[A-Za-z0-9][A-Za-z0-9_ -]*[A-Za-z0-9]$",
-                    "examples": [
-                        "Microsoft Enterprise"
-                    ]
+                    "$ref": "#/components/schemas/CloudMatrix.TemplateName"
                 },
                 "examples": {
-                    "valid template name": {
+                    "Valid Template Name": {
                         "summary": "Example Valid Template Name",
                         "description": "An example string of a valid template name.",
                         "value": "Microsoft Enterprise"
@@ -4536,16 +4530,7 @@
                 "type": "object",
                 "properties": {
                     "templateName": {
-                        "type": "string",
-                        "minLength": 2,
-                        "maxLength": 100,
-                        "pattern": "^[A-Za-z0-9][A-Za-z0-9_ -]*[A-Za-z0-9]$",
-                        "description": "A valid template name allows alphanumeric characters, spaces, underscores, and hyphens, but may not start or end with special characters.",
-                        "examples": [
-                            "Microsoft Enterprise",
-                            "Microsoft_Academic",
-                            "Google-Workspace"
-                        ]
+                        "$ref": "#/components/schemas/CloudMatrix.TemplateName"
                     },
                     "templateContent": {
                         "$ref": "#/components/schemas/CloudMatrix.BulkCloudMatrix"
@@ -4726,6 +4711,18 @@
                             ]
                         }
                     }
+                ]
+            },
+            "CloudMatrix.TemplateName": {
+                "type": "string",
+                "minLength": 2,
+                "maxLength": 100,
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9_ -]*[A-Za-z0-9]$",
+                "description": "A valid template name allows alphanumeric characters, spaces, underscores, and hyphens, but may not start or end with special characters.",
+                "examples": [
+                    "Microsoft Enterprise",
+                    "Microsoft_Academic",
+                    "Google-Workspace"
                 ]
             }
         },

--- a/src/dataGateway/TypeScript/package.json
+++ b/src/dataGateway/TypeScript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shi-corp/sdk-data-gateway",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "type": "module",
     "main": "bin/index.js",
     "description": "SDK client used to interface with the SHI Data Gateway service.",


### PR DESCRIPTION
- Update OpenAPI spec to support retrieving Cloud Matrix templates by name:
- Add a required path parameter `templateName`, change the GET path to `/Api/CloudMatrix/Template/{templateName}` (with updated operationId, descriptions and examples), and adjust response summaries.
- Preserve the POST endpoint for creating/updating templates.
- Also bump the TypeScript SDK package version from 3.2.0 to 3.2.1.